### PR TITLE
Plant Demo Modes + resolving script linking issue

### DIFF
--- a/Assets/Base/Scenes/Farm.unity
+++ b/Assets/Base/Scenes/Farm.unity
@@ -2251,12 +2251,32 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4700762893281174335, guid: ab8030125d738994b9f837a51fe7428f, type: 3}
+      propertyPath: activateGrowthDemo
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4700762893281174335, guid: ab8030125d738994b9f837a51fe7428f, type: 3}
       propertyPath: currentGrowthStage
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4700762893281174335, guid: ab8030125d738994b9f837a51fe7428f, type: 3}
       propertyPath: growthTimeModifier
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4700762893281174335, guid: ab8030125d738994b9f837a51fe7428f, type: 3}
+      propertyPath: demoGrowthTimeModifier
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4700762893281174335, guid: ab8030125d738994b9f837a51fe7428f, type: 3}
+      propertyPath: waterHourlyConsumption
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4700762893281174335, guid: ab8030125d738994b9f837a51fe7428f, type: 3}
+      propertyPath: activateDemoTerrainInit
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4700762893281174335, guid: ab8030125d738994b9f837a51fe7428f, type: 3}
+      propertyPath: nutrientHourlyConsumption
+      value: 0.1
       objectReference: {fileID: 0}
     - target: {fileID: 5042387047738368134, guid: ab8030125d738994b9f837a51fe7428f, type: 3}
       propertyPath: harvestMaterial
@@ -2286,6 +2306,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Corn
       objectReference: {fileID: 0}
+    - target: {fileID: 5755419149136521195, guid: ab8030125d738994b9f837a51fe7428f, type: 3}
+      propertyPath: m_TagString
+      value: Plant
+      objectReference: {fileID: 0}
     - target: {fileID: 6727733167930865540, guid: ab8030125d738994b9f837a51fe7428f, type: 3}
       propertyPath: m_Size.x
       value: 2.37
@@ -2308,7 +2332,7 @@ PrefabInstance:
       objectReference: {fileID: 927335752}
     - target: {fileID: 7281002823166359556, guid: ab8030125d738994b9f837a51fe7428f, type: 3}
       propertyPath: Response.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7281002823166359556, guid: ab8030125d738994b9f837a51fe7428f, type: 3}
       propertyPath: Response.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName

--- a/Assets/Base/Scripts/Type.cs
+++ b/Assets/Base/Scripts/Type.cs
@@ -23,6 +23,7 @@ namespace Base
         Fruit_Corn,
         Fruit_Tomato,
         Fruit_Onion,
+        Fruit_Pepper,
         Fruit_End,
     }
 }

--- a/Assets/Plants/Resources/PlantPrefabs/Corn.prefab
+++ b/Assets/Plants/Resources/PlantPrefabs/Corn.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 4700762893281174335}
   - component: {fileID: 4923028307458688226}
   - component: {fileID: 7281002823166359556}
+  - component: {fileID: 32021375285803428}
   m_Layer: 0
   m_Name: Corn
   m_TagString: Untagged
@@ -55,11 +56,16 @@ MonoBehaviour:
   waterLevel: 0
   waterUpperLimit: 1
   waterLowerLimit: 0
+  waterHourlyConsumption: 0.1
   nutrientLevel: 0
   nutrientUpperLimit: 1
   nutrientLowerLimit: 0
+  nutrientHourlyConsumption: 0.1
   currentGrowthStage: 0
-  growthTimeModifier: 5
+  daysUntilMaturity: 50
+  activateGrowthDemo: 0
+  demoGrowthTimeModifier: 3
+  activateDemoTerrainInit: 0
 --- !u!65 &4923028307458688226
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -91,7 +97,35 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 4700762893281174335}
         m_TargetAssemblyTypeName: Plant, AssembelyDefinitions
-        m_MethodName: yellAtHour
+        m_MethodName: HourlyUpdate
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &32021375285803428
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5755419149136521195}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96a325c29958217419c783504cabafa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Event: {fileID: 11400000, guid: 03c86adfaa7217c4dbe2f75663949d01, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4700762893281174335}
+        m_TargetAssemblyTypeName: Plant, AssembelyDefinitions
+        m_MethodName: DailyUpdate
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Plants/Resources/PlantPrefabs/Onion.prefab
+++ b/Assets/Plants/Resources/PlantPrefabs/Onion.prefab
@@ -128,6 +128,8 @@ GameObject:
   - component: {fileID: 8456606131754610749}
   - component: {fileID: 8449122893976940062}
   - component: {fileID: 4379087214095187673}
+  - component: {fileID: 5305627167616605833}
+  - component: {fileID: 874773429707600688}
   m_Layer: 0
   m_Name: Onion
   m_TagString: Untagged
@@ -162,20 +164,25 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fb98494fb9598d149989f16fd4dac441, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  fruitType: 0
-  plantName: 
+  fruitType: 16
+  plantName: Onion
   currentHealthStatus: 3
   fruitWeightScale: 1
   lightLevel: 0
-  lightLoving: 0
+  lightLoving: 1
   waterLevel: 0
-  waterUpperLimit: 0
+  waterUpperLimit: 1
   waterLowerLimit: 0
+  waterHourlyConsumption: 0.1
   nutrientLevel: 0
-  nutrientUpperLimit: 0
+  nutrientUpperLimit: 1
   nutrientLowerLimit: 0
+  nutrientHourlyConsumption: 0.1
   currentGrowthStage: 0
-  growthTimeModifier: 5
+  daysUntilMaturity: 55
+  activateGrowthDemo: 0
+  demoGrowthTimeModifier: 0
+  activateDemoTerrainInit: 0
 --- !u!65 &4379087214095187673
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -189,3 +196,59 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &5305627167616605833
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4881054833026041909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96a325c29958217419c783504cabafa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Event: {fileID: 11400000, guid: 03c86adfaa7217c4dbe2f75663949d01, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8449122893976940062}
+        m_TargetAssemblyTypeName: Plant, AssembelyDefinitions
+        m_MethodName: DailyUpdate
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &874773429707600688
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4881054833026041909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96a325c29958217419c783504cabafa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Event: {fileID: 11400000, guid: eeb0257e87c1ba34081517bbe3330fed, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8449122893976940062}
+        m_TargetAssemblyTypeName: Plant, AssembelyDefinitions
+        m_MethodName: HourlyUpdate
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2

--- a/Assets/Plants/Resources/PlantPrefabs/Pepper.prefab
+++ b/Assets/Plants/Resources/PlantPrefabs/Pepper.prefab
@@ -11,6 +11,8 @@ GameObject:
   - component: {fileID: 9217613691797672466}
   - component: {fileID: 3219458760253792301}
   - component: {fileID: 167984628286711957}
+  - component: {fileID: 6778902705080961766}
+  - component: {fileID: 4780906509504543216}
   m_Layer: 0
   m_Name: Pepper
   m_TagString: Untagged
@@ -58,20 +60,81 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fb98494fb9598d149989f16fd4dac441, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  fruitType: 0
-  plantName: 
+  fruitType: 17
+  plantName: Pepper
   currentHealthStatus: 3
   fruitWeightScale: 1
   lightLevel: 0
-  lightLoving: 0
+  lightLoving: 1
   waterLevel: 0
   waterUpperLimit: 1
   waterLowerLimit: 0
+  waterHourlyConsumption: 0.1
   nutrientLevel: 0
   nutrientUpperLimit: 1
   nutrientLowerLimit: 0
+  nutrientHourlyConsumption: 0.1
   currentGrowthStage: 0
-  growthTimeModifier: 2
+  daysUntilMaturity: 90
+  activateGrowthDemo: 0
+  demoGrowthTimeModifier: 0
+  activateDemoTerrainInit: 0
+--- !u!114 &6778902705080961766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 811730888934120603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96a325c29958217419c783504cabafa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Event: {fileID: 11400000, guid: 03c86adfaa7217c4dbe2f75663949d01, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 167984628286711957}
+        m_TargetAssemblyTypeName: Plant, AssembelyDefinitions
+        m_MethodName: DailyUpdate
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &4780906509504543216
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 811730888934120603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96a325c29958217419c783504cabafa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Event: {fileID: 11400000, guid: eeb0257e87c1ba34081517bbe3330fed, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 167984628286711957}
+        m_TargetAssemblyTypeName: Plant, AssembelyDefinitions
+        m_MethodName: HourlyUpdate
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &2989714009743982152
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Plants/Resources/PlantPrefabs/Tomato.prefab
+++ b/Assets/Plants/Resources/PlantPrefabs/Tomato.prefab
@@ -9,6 +9,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7086876473282059087}
+  - component: {fileID: 2856203950263715833}
+  - component: {fileID: 5577140170496073911}
+  - component: {fileID: 8163858099575312248}
+  - component: {fileID: 4819973919261554625}
   m_Layer: 0
   m_Name: Tomato
   m_TagString: Untagged
@@ -26,7 +30,225 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 212384920217776976}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2856203950263715833
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 741922505298151880}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &5577140170496073911
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 741922505298151880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb98494fb9598d149989f16fd4dac441, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fruitType: 15
+  plantName: Tomato
+  currentHealthStatus: 3
+  fruitWeightScale: 1
+  lightLevel: 0
+  lightLoving: 1
+  waterLevel: 0
+  waterUpperLimit: 1
+  waterLowerLimit: 0
+  waterHourlyConsumption: 0.1
+  nutrientLevel: 0
+  nutrientUpperLimit: 1
+  nutrientLowerLimit: 0
+  nutrientHourlyConsumption: 0.1
+  currentGrowthStage: 0
+  daysUntilMaturity: 100
+  activateGrowthDemo: 0
+  demoGrowthTimeModifier: 0
+  activateDemoTerrainInit: 0
+--- !u!114 &8163858099575312248
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 741922505298151880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96a325c29958217419c783504cabafa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Event: {fileID: 11400000, guid: eeb0257e87c1ba34081517bbe3330fed, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5577140170496073911}
+        m_TargetAssemblyTypeName: Plant, AssembelyDefinitions
+        m_MethodName: HourlyUpdate
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &4819973919261554625
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 741922505298151880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96a325c29958217419c783504cabafa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Event: {fileID: 11400000, guid: 03c86adfaa7217c4dbe2f75663949d01, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5577140170496073911}
+        m_TargetAssemblyTypeName: Plant, AssembelyDefinitions
+        m_MethodName: DailyUpdate
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &8216011000099010925
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 212384920217776976}
+  - component: {fileID: 38531185632470673}
+  - component: {fileID: 7258370471943269144}
+  - component: {fileID: 5593927963602390491}
+  - component: {fileID: 1317136376339105531}
+  m_Layer: 0
+  m_Name: TomatoVisuals
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &212384920217776976
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8216011000099010925}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7086876473282059087}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &38531185632470673
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8216011000099010925}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a706d61a320aa74f8b831e94ab91575, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  size: {x: 2, y: 2}
+  mat: {fileID: 0}
+  rend: {fileID: 5593927963602390491}
+  cam: {fileID: 0}
+--- !u!33 &7258370471943269144
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8216011000099010925}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5593927963602390491
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8216011000099010925}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &1317136376339105531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8216011000099010925}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 90815d1ccb2b637419c4ee1a503febba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  seedlingMaterial: {fileID: 2100000, guid: f39e2f67eba9982429d7c7f243feb95f, type: 2}
+  vegetation1Material: {fileID: 2100000, guid: 147d5ffdddc405441bc488a1ac1d4fa4, type: 2}
+  vegetation2Material: {fileID: 2100000, guid: 9225a61e8f9d9154dad98cc031031924, type: 2}
+  floweringMaterial: {fileID: 2100000, guid: 1607108afe0350c4fb70acdd6db95967, type: 2}
+  fruitingMaterial: {fileID: 2100000, guid: 1607108afe0350c4fb70acdd6db95967, type: 2}
+  harvestMaterial: {fileID: 2100000, guid: 565c2dba0eb03994d8dbc69377bf9aa1, type: 2}

--- a/Assets/Plants/Sprites/Tomato/tomato_3.mat
+++ b/Assets/Plants/Sprites/Tomato/tomato_3.mat
@@ -7,7 +7,7 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: tomato_2
+  m_Name: tomato_3
   m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
@@ -44,7 +44,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 18233de2af72a3c49a521f44fdfb1d44, type: 3}
+        m_Texture: {fileID: 2800000, guid: cb9b1d48e5191ad429ae3fa91bfbb84f, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:

--- a/Assets/Plants/Sprites/Tomato/tomato_4.mat
+++ b/Assets/Plants/Sprites/Tomato/tomato_4.mat
@@ -7,7 +7,7 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: tomato_2
+  m_Name: tomato_4
   m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
@@ -44,7 +44,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 18233de2af72a3c49a521f44fdfb1d44, type: 3}
+        m_Texture: {fileID: 2800000, guid: 5ae74fefb8b626f4cb45d1847bc2377a, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:

--- a/Assets/Plants/Sprites/Tomato/tomato_5.mat
+++ b/Assets/Plants/Sprites/Tomato/tomato_5.mat
@@ -7,7 +7,7 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: tomato_2
+  m_Name: tomato_5
   m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
@@ -44,7 +44,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 18233de2af72a3c49a521f44fdfb1d44, type: 3}
+        m_Texture: {fileID: 2800000, guid: 64243087f6968494abdd20960c44db12, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:


### PR DESCRIPTION
Added two demo modes to plants:
accelerated growth: plants are decoupled from event system and develop in a short time
terrain initialization: plant will supply its terrain tile with nutrients and water upon initialization 

Additionally, updated plant prefabs and farm scene in hopes of resolving script linking issues